### PR TITLE
deprecating 'working group' name

### DIFF
--- a/_layouts/header-footer.html
+++ b/_layouts/header-footer.html
@@ -94,7 +94,7 @@
           <h5>Community</h5>
           <p><a href="https://tisch.nyu.edu/itp" target="_blank">ITP/IMA</a></p>
           <p>
-            <a href="https://itp.nyu.edu/groups/equitable/" target="_blank">ITP/IMA Equitability Working Group</a>
+            <a href="https://itp.nyu.edu/groups/equitable/" target="_blank">Equitable ITP/IMA</a>
           </p>
           <p><a href="https://itp-techandsociety.github.io/online/" target="_blank">Tech & Society</a></p>
         </div>


### PR DESCRIPTION
Updating the name of the working group to more general purpose "equitable ITP/IMA"